### PR TITLE
fix(http-log): add port information to the host header

### DIFF
--- a/changelog/unreleased/kong/fix-http-log-host-header.yml
+++ b/changelog/unreleased/kong/fix-http-log-host-header.yml
@@ -1,0 +1,3 @@
+message: "**HTTP-Log**: Fix an issue where the plugin doesn't include port information in the HTTP host header when sending requests to the log server."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -114,7 +114,6 @@ local function send_entries(conf, entries)
   httpc:set_timeout(timeout)
 
   local headers = {
-    ["Host"] = host,
     ["Content-Type"] = content_type,
     ["Content-Length"] = content_length,
     ["Authorization"] = userinfo and "Basic " .. encode_base64(userinfo) or nil

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -209,6 +209,22 @@ for _, strategy in helpers.each_strategy() do
         }
       }
 
+      local route5 = bp.routes:insert {
+        hosts   = { "http_host_header.test" },
+        service = service1
+      }
+
+      bp.plugins:insert {
+        route  = { id = route5.id },
+        name   = "http-log",
+        config = {
+          http_endpoint = "http://" .. helpers.mock_upstream_host
+                                    .. ":"
+                                    .. helpers.mock_upstream_port
+                                    .. "/post_log/http_host_header"
+        }
+      }
+
       local route6 = bp.routes:insert {
         hosts   = { "https_logging_faulty.test" },
         service = service2
@@ -535,6 +551,29 @@ for _, strategy in helpers.each_strategy() do
       assert.same(vault_env_value, entries[1].log_req_headers.key2)
     end)
 
+    it("http client implicitly adds Host header", function()
+      reset_log("http_host_header")
+      local res = proxy_client:get("/status/200", {
+        headers = {
+          ["Host"] = "http_host_header.test"
+        }
+      })
+      assert.res_status(200, res)
+
+      local entries = get_log("http_host_header", 1)
+      local host_header
+      if helpers.mock_upstream_port == 80 then
+        host_header = helpers.mock_upstream_host
+      else
+        host_header = helpers.mock_upstream_host .. ":" .. helpers.mock_upstream_port
+      end
+      for name, value in pairs(entries[1].log_req_headers) do
+        if name == "host" then
+          assert.same(host_header, value)
+          break
+        end
+      end
+    end)
 
     it("puts changed configuration into effect immediately", function()
         local admin_client = assert(helpers.admin_client())


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Add port to host header when non-default port is used.The log server receives requests with a host header that does not include the port number.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #13067