### PR TITLE
Fix/http log host header test

### DIFF
--- a/changelog/unreleased/kong/fix-http-log-host-header.yml
+++ b/changelog/unreleased/kong/fix-http-log-host-header.yml
@@ -1,0 +1,3 @@
+message: "**HTTP-Log**: Fix an issue where the plugin doesn't include port information in the HTTP host header when sending requests to the log server."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -114,7 +114,6 @@ local function send_entries(conf, entries)
   httpc:set_timeout(timeout)
 
   local headers = {
-    ["Host"] = host,
     ["Content-Type"] = content_type,
     ["Content-Length"] = content_length,
     ["Authorization"] = userinfo and "Basic " .. encode_base64(userinfo) or nil

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -561,12 +561,12 @@ for _, strategy in helpers.each_strategy() do
       assert.res_status(200, res)
 
       local entries = get_log("http_host_header", 1)
-      local host_header
-      if helpers.mock_upstream_port == 80 then
-        host_header = helpers.mock_upstream_host
-      else
-        host_header = helpers.mock_upstream_host .. ":" .. helpers.mock_upstream_port
-      end
+      local host_header = helpers.mock_upstream_host
+      -- if helpers.mock_upstream_port == 80 then
+      --   host_header = helpers.mock_upstream_host
+      -- else
+      --   host_header = helpers.mock_upstream_host .. ":" .. helpers.mock_upstream_port
+      -- end
       assert.same(entries[1].log_req_headers['host'] or "", host_header)
     end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
