### PR TITLE
Fix/jwt query args limiting 2

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -11,6 +11,7 @@ local ipairs = ipairs
 local pairs = pairs
 local tostring = tostring
 local re_gmatch = ngx.re.gmatch
+local search_get_all = require("resty.ada.search").get_all
 
 
 local JwtHandler = {
@@ -27,19 +28,12 @@ local JwtHandler = {
 -- @return err
 local function retrieve_tokens(conf)
   local token_set = {}
-  local args = kong.request.get_query()
+  local query = kong.request.get_raw_query()
   for _, v in ipairs(conf.uri_param_names) do
-    local token = args[v] -- can be a table
-    if token then
-      if type(token) == "table" then
-        for _, t in ipairs(token) do
-          if t ~= "" then
-            token_set[t] = true
-          end
-        end
-
-      elseif token ~= "" then
-        token_set[token] = true
+    local token = search_get_all(query, v)
+    for _, t in ipairs(token) do
+      if t ~= "" then
+        token_set[t] = true
       end
     end
   end

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -470,6 +470,26 @@ for _, strategy in helpers.each_strategy() do
         assert.same({ message = "Multiple tokens provided" }, body)
         assert.equal('Bearer error="invalid_token"', res.headers["WWW-Authenticate"])
       end)
+
+      it("accepts token parameter index in query args to exceed 100", function()
+        PAYLOAD.iss = jwt_secret.key
+        local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+        local str_args, table_args = "", {}
+        for i = 1, 101 do
+          table.insert(table_args, "k" .. i .."=v" .. i)
+        end
+        str_args = table.concat(table_args, "&")
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request?" .. str_args .. "&jwt=" .. jwt,
+          headers = {
+            ["Host"] = "jwt1.test",
+          }
+        })
+        local body = cjson.decode(assert.res_status(401, res))
+        assert.same({ message = "Multiple tokens provided" }, body)
+        assert.equal('Bearer error="invalid_token"', res.headers["WWW-Authenticate"])
+      end)
     end)
 
     describe("HS256", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
